### PR TITLE
Fix/batch

### DIFF
--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -260,11 +260,6 @@ cat:hasObjective a rdf:Property ;
     skos:definition "The objective that is part of the batch" ;
     .
 
-cat:hasCampaign a rdf:Property ;
-    skos:prefLabel "has campaign" ;
-    skos:definition "The campaign that is part of the batch" ;
-    .
-
 cat:hasBatch a rdf:Property ;
     skos:prefLabel "has batch" ;
     skos:definition "refers to a specific batch instance" ;

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -857,6 +857,7 @@ cat:Batch a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Batch" ;
     skos:definition "A batch is a group of samples that are processed together." ;
     sh:property [sh:path schema:name ; sh:datatype xsd:string] ;
+    sh:property [sh:path purl:identifier ; sh:datatype xsd:string] ;
     sh:property [sh:path cat:reactionType ; sh:datatype xsd:string] ;
     sh:property [sh:path allo-res:AFR_0002764 ; sh:datatype xsd:string] ;
     sh:property [sh:path allo-hdf:HardLink ; sh:datatype xsd:string] ;

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -556,7 +556,7 @@ allo-res:AFR_0002374 a rdf:Property ;
 
 purl:identifier a rdf:Property ;
     skos:prefLabel "identifier" ;
-    skos:definition "an identifier of a sample" ;
+    skos:definition "An unambiguous reference to the resource within a given context." ;
     .
 
 cat:hasWell a rdf:Property ;


### PR DESCRIPTION
This PR does the following:
- it adds an `identifier` property to the Batch so that the batchID can be mapped
- it removes the unused `cat:hasCampaign property' that has been previously on `cat:Batch`

An alternative to the proposed approach would be to add a `cat:batchID`. So @rmfranken would you have an opinion about what approach to take in this regard?