### PR TITLE
fix: obo:CHEBI_25367

### DIFF
--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -803,7 +803,7 @@ cat:Product a sh:NodeShape, rdfs:Class ;
 obo:CHEBI_25367 a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf chebi:CHEBI_36357 ;
     sh:property [sh:path purl:identifier ; sh:datatype xsd:string ; sh:minCount 1 ; sh:maxCount 1] ;
-    sh:property [sh:path cat:swissCatNumber; sh:datatype xsd:string ; sh:minCount 1 ; sh:maxCount 1] ;
+    sh:property [sh:path cat:swissCatNumber; sh:datatype xsd:string ; sh:minCount 1] ;
     sh:property [sh:path cat:casNumber ; sh:datatype xsd:string] ;
     sh:property [sh:path allo-res:AFR_0002292 ; sh:datatype xsd:string] ; #chemical name
     sh:property [sh:path allo-res:AFR_0002295 ; sh:datatype xsd:string] ; #smiles

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -803,8 +803,8 @@ cat:Product a sh:NodeShape, rdfs:Class ;
 obo:CHEBI_25367 a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf chebi:CHEBI_36357 ;
     sh:property [sh:path purl:identifier ; sh:datatype xsd:string ; sh:minCount 1 ; sh:maxCount 1] ;
-    sh:xone ([sh:property [sh:path cat:casNumber ; sh:datatype xsd:string ; sh:minCount 1] ] 
-             [sh:property [sh:path cat:swissCatNumber; sh:datatype xsd:string ; sh:minCount 1]] ); #Swisscat number EXCLUSIVE OR CAS Number
+    sh:property [sh:path cat:swissCatNumber; sh:datatype xsd:string ; sh:minCount 1 ; sh:maxCount 1] ;
+    sh:property [sh:path cat:casNumber ; sh:datatype xsd:string] ;
     sh:property [sh:path allo-res:AFR_0002292 ; sh:datatype xsd:string] ; #chemical name
     sh:property [sh:path allo-res:AFR_0002295 ; sh:datatype xsd:string] ; #smiles
     sh:property [sh:path allo-res:AFR_0002294 ;


### PR DESCRIPTION
* Chemicals have always a `cat:swissCatNumber` and may have also a `cat:casNumber`, see: https://github.com/sdsc-ordes/catplus-ontology/pull/41