### PR TITLE
refactor: minimal data change: rename `hasContainerPositionAndQuantity`

### DIFF
--- a/json-file/1-Synth/1-Synth.json
+++ b/json-file/1-Synth/1-Synth.json
@@ -47,7 +47,7 @@
             },
             "equipmentName": "Chemspeed SWING XL",
             "subEquipmentName": "GDU-V",
-            "hasContainerPositionAndQuantity": [
+            "hasWell": [
                 {
                     "position": "A1",
                     "containerID": "1",
@@ -126,7 +126,7 @@
             },
             "equipmentName": "Chemspeed SWING XL",
             "subEquipmentName": "GDU-V",
-            "hasContainerPositionAndQuantity": [
+            "hasWell": [
                 {
                     "position": "A1",
                     "containerID": "1",
@@ -217,7 +217,7 @@
             },
             "equipmentName": "Chemspeed SWING XL",
             "subEquipmentName": "GDU-V",
-            "hasContainerPositionAndQuantity": [
+            "hasWell": [
                 {
                     "position": "A1",
                     "containerID": "1",
@@ -308,7 +308,7 @@
             },
             "equipmentName": "Chemspeed SWING XL",
             "subEquipmentName": "GDU-V",
-            "hasContainerPositionAndQuantity": [
+            "hasWell": [
                 {
                     "position": "A1",
                     "containerID": "1",

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -626,7 +626,6 @@ cat:reactionName a rdf:Property ;
 cat:AddAction a rdfs:Class, sh:NodeShape ;
    rdfs:subClassOf allo-real:AFRE_0000001 ;
    sh:property [sh:path cat:dispenseType ; sh:datatype xsd:string] ;
-   sh:property [sh:path cat:hasWell ; sh:class cat:Well ] ;
    sh:property [sh:path allo-qual:AFQ_0000111 ;
                 sh:xone ([ sh:hasValue "Solid"]
                         [sh:hasValue "Liquid"]) ; ] ; #state of matter / dispense state
@@ -690,13 +689,15 @@ cat:SolventChangeAction a rdfs:Class, sh:NodeShape ;
 allo-real:AFRE_0000001 a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Action" ;
     skos:definition "An action is a unit element in a procedure and is a concretization of an action specification." ;
+    # an action can either relates to several wells or to the full plate
+    sh:property [sh:path cat:hasPlate ; sh:class cat:Plate] ; #hasPlate
+    sh:property [sh:path cat:hasWell ; sh:class cat:Well] ; #hasWell
     sh:property [sh:path allo-res:AFR_0001723 ; sh:datatype xsd:string ] ;#Equipment name ,
     sh:property [sh:path cat:subEquipmentName ; sh:datatype xsd:string ] ;#subEquipmentName
     sh:property [sh:path schema:name ; sh:datatype xsd:string ] ; #name
     sh:property [sh:path allo-prop:AFX_0000622 ; sh:datatype xsd:dateTime ] ;#startTime ,
     sh:property [sh:path allo-res:AFR_0002423 ; sh:datatype xsd:dateTime ] ;#endTime ,
     sh:property [sh:path allo-res:AFR_0001606 ; sh:datatype xsd:string ] ;#methodName
-    sh:property [sh:path cat:hasPlate ; sh:class cat:Plate] ; #hasPlate
     sh:property [sh:path cat:hasBatch ; sh:class cat:Batch] ; #hasBatch
     sh:property [sh:path cat:order ; sh:datatype xsd:string ] #order
     .
@@ -789,6 +790,7 @@ cat:Sample a rdfs:Class, sh:NodeShape ;
                     sh:node cat:Observation ;
                     sh:node [sh:property    [sh:path qudt:unit ;
                                             sh:hasValue unit:PERCENT] ]];
+    sh:property [sh:path cat:hasPlate ; sh:class cat:Plate] ; # hasPlate
     sh:property [sh:path cat:hasSample ; sh:class cat:Sample] ; #hasSample
     sh:property [sh:path cat:hasChemical ; sh:class obo:CHEBI_25367 ] ; #hasChemical
     .
@@ -865,7 +867,6 @@ cat:Batch a rdfs:Class, sh:NodeShape ;
 cat:Plate a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Plate" ;
     skos:definition "A plate is a flat, rigid structure that holds samples or reagents in an experiment." ;
-    sh:property [sh:path cat:hasWell ; sh:class cat:Well] ; #hasWell
     sh:property [sh:path cat:internalBarCode ; sh:datatype xsd:string] ; #internal barcode
     sh:property [sh:path cat:containerBarcode ; sh:datatype xsd:string] ; #container barcode
     sh:property [sh:path cat:containerID ; sh:datatype xsd:string] ; #containerID
@@ -875,12 +876,13 @@ cat:Well a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Well" ;
     skos:definition "A well is a small container used to hold samples or reagents in an experiment." ; 
     sh:property [sh:path allo-res:AFR_0002240 ; sh:datatype xsd:string] ; #Well location identifier
+    sh:property [sh:path cat:hasWell ; sh:class cat:Plate] ; #hasPlate
     sh:property [sh:path qudt:quantity ;
                  sh:node cat:Observation ] ;
         sh:xone ([sh:property [sh:path cat:hasProduct ; sh:class cat:Product ]]  #hasProduct
                  [sh:property [sh:path cat:peak ; sh:class allo-res:AFR_0000413 ]] ); #peak
 
-    .   
+    .
 
 allo-res:AFR_0002525 a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Liquid Chromatography Document" ;


### PR DESCRIPTION
data changes: (I have tried to keep them minimal)

* use `hasWell` instead of `hasContainerPositionAndQuantity` in the data

ontology changes: (I have tried to align the changes more to the data, to make them pragmatic)

* remove `hasWell` from `cat:Plate` and add `cat:hasPlate` on `cat:Well` instead:
this seems more aligned to the data to

* add on `allo-real:AFRE_0000001` both `hasWell` and `hasPlate`:
every action targets either several well or the full plate
we could flesh that out further later with an `xor` if needed