### PR TITLE
fix: `cat:swissCatNumber`

### DIFF
--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -806,7 +806,7 @@ cat:Product a sh:NodeShape, rdfs:Class ;
 obo:CHEBI_25367 a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf chebi:CHEBI_36357 ;
     sh:property [sh:path purl:identifier ; sh:datatype xsd:string ; sh:minCount 1 ; sh:maxCount 1] ;
-    sh:property [sh:path cat:swissCatNumber; sh:datatype xsd:string ; sh:minCount 1] ;
+    sh:property [sh:path cat:swissCatNumber; sh:datatype xsd:string] ;
     sh:property [sh:path cat:casNumber ; sh:datatype xsd:string] ;
     sh:property [sh:path allo-res:AFR_0002292 ; sh:datatype xsd:string] ; #chemical name
     sh:property [sh:path allo-res:AFR_0002295 ; sh:datatype xsd:string] ; #smiles


### PR DESCRIPTION
Don't make that property mandatory, since it is okay if a Chemical has a `cat:casNumber` instead. We can make the demand stronger later if needed. As we have been told, the `cat:casNumber` is not always there in that cases a `cat:swissCasNumber` is provided. In principle it can always be provided, but the current data don't always have it.