### PR TITLE
fix: `unit:Bar` was mispelled as `bar` in the `cat:SetVacuumAction`

### DIFF
--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -656,7 +656,7 @@ cat:SetVacuumAction a rdfs:Class, sh:NodeShape ;
     sh:property [sh:path cat:vacuum ; #vacuum
                  sh:node cat:Observation ;
                  sh:node [sh:property    [sh:path qudt:unit ;
-                                            sh:hasValue unit:bar] ]];
+                                            sh:hasValue unit:Bar] ]];
     .
 
 cat:ShakeAction a rdfs:Class, sh:NodeShape ;


### PR DESCRIPTION
capitalize to `Bar` to conform to namespace