### PR TITLE
fix: startTime and endingTime in Bravo metadata

### DIFF
--- a/json-file/3-Bravo/3-Bravo-part1.json
+++ b/json-file/3-Bravo/3-Bravo-part1.json
@@ -2,7 +2,7 @@
     "Actions": [
         {
             "actionName": "EvaporationAction",
-            "subActionName": "",
+            "methodName": "evaporate",
             "equipmentName": "Evaporator",
             "subEquipmentName": "item-1",
             "volumeEvaporationFinal": {
@@ -11,10 +11,14 @@
             },
             "startTime": "2024-07-25T12:03:31",
             "endingTime": "2024-07-25T12:15:20",
-            "sampleID": "26",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "temperature": {
                 "value": 156,
                 "unit": "°C",
@@ -26,18 +30,22 @@
             "order": "1"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "DilutionAddAction",
+            "methodName": "dilution",
             "subActionName": "Dilution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "26",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "14",
@@ -48,7 +56,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "O",
-                    "swissCatNumber": "",
                     "Inchi": "1S/H2O/h1H2",
                     "molecularFormula": "H2O",
                     "density": {
@@ -68,24 +75,31 @@
             "order": "2"
         },
         {
-            "actionName": "solventChange",
+            "actionName": "solventChangeAction",
+            "methodName": "separation-cartridge-part-1",
             "subActionName": "separation-cartridge-part-1",
             "equipmentName": "SPE",
             "subEquipmentName": "cartridge exchange",
             "SPMEprocess": true,
-            "sampleID": "26",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasCartridge": {
                 "cartridgeName": "test-cartridge",
                 "cartridgeComposition": "test-material"
             },
-            "startTime": {
+            "startTime": "2024-07-25T12:03:31",
+            "endingTime": "2024-07-25T12:15:20",
+            "startDuration": {
                 "value": 0,
                 "unit": "min"
             },
-            "endingTime": {
+            "endingDuration": {
                 "value": 1,
                 "unit": "min"
             },
@@ -99,7 +113,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "CC#N",
-                    "swissCatNumber": "",
                     "Inchi": "1S/C2H3N/c1-2-3/h1H3",
                     "molecularFormula": "C2H3N",
                     "density": {
@@ -119,24 +132,31 @@
             "order": "3"
         },
         {
-            "actionName": "solventChange",
+            "actionName": "solventChangeAction",
+            "methodName": "separation-cartridge-part-2",
             "subActionName": "separation-cartridge-part-2",
             "equipmentName": "SPE",
             "subEquipmentName": "cartridge exchange",
             "SPMEprocess": true,
-            "sampleID": "26",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasCartridge": {
                 "cartridgeName": "C18cartridge",
                 "cartridgeComposition": "C18"
             },
-            "startTime": {
+            "startTime": "2024-07-25T12:03:31",
+            "endingTime": "2024-07-25T12:15:20",
+            "startDuration": {
                 "value": 1,
                 "unit": "min"
             },
-            "endingTime": {
+            "endingDuration": {
                 "value": 7,
                 "unit": "min"
             },
@@ -150,7 +170,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "CC#N",
-                    "swissCatNumber": "",
                     "Inchi": "1S/C2H3N/c1-2-3/h1H3",
                     "molecularFormula": "C2H3N",
                     "density": {

--- a/json-file/3-Bravo/3-Bravo-part2-1.json
+++ b/json-file/3-Bravo/3-Bravo-part2-1.json
@@ -2,7 +2,7 @@
     "Actions": [
         {
             "actionName": "EvaporationAction",
-            "subActionName": "",
+            "methodName": "evaporation",
             "equipmentName": "Evaporator",
             "subEquipmentName": "item-1",
             "volumeEvaporationFinal": {
@@ -11,11 +11,15 @@
             },
             "startTime": "2024-07-25T12:03:31",
             "endingTime": "2024-07-25T12:15:20",
-            "sampleID": "25",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "temperature": {
                 "value": 156,
                 "unit": "°C",
@@ -28,7 +32,6 @@
         },
         {
             "actionName": "EvaporationAction",
-            "subActionName": "",
             "equipmentName": "Evaporator",
             "subEquipmentName": "item-1",
             "volumeEvaporationFinal": {
@@ -37,11 +40,15 @@
             },
             "startTime": "2024-07-25T12:03:31",
             "endingTime": "2024-07-25T12:15:20",
-            "sampleID": "26",
-            "containerID": "158",
-            "containerBarcode": "1234858858754849",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "temperature": {
                 "value": 156,
                 "unit": "°C",
@@ -53,19 +60,23 @@
             "order": "2"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "DissolutionAddAction",
             "subActionName": "Dissolution",
+            "methodName": "dissolution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "25",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "25",
@@ -76,13 +87,8 @@
                         "unit": "g/mol"
                     },
                     "smiles": "[2H]C([2H])([2H])O[2H]",
-                    "swissCatNumber": "",
                     "Inchi": "1S/CH4O/c1-2/h2H,1H3/i1D3,2D",
-                    "molecularFormula": "CH4O",
-                    "density": {
-                        "value": "",
-                        "unit": "g/mL"
-                    }
+                    "molecularFormula": "CH4O"
                 },
                 "volume": {
                     "value": 0.2,
@@ -96,19 +102,23 @@
             "order": "3"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "DissolutionAddAction",
             "subActionName": "Dissolution",
+            "methodName": "dissolution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "26",
-            "containerID": "158",
-            "containerBarcode": "1234858858754849",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "59",
@@ -119,13 +129,8 @@
                         "unit": "g/mol"
                     },
                     "smiles": "[2H]C([2H])([2H])OC(C)(C)C",
-                    "swissCatNumber": "",
                     "Inchi": "1S/C5H12O/c1-5(2,3)6-4/h1-4H3/i4D3",
-                    "molecularFormula": "C5H12O",
-                    "density": {
-                        "value": "",
-                        "unit": "g/mL"
-                    }
+                    "molecularFormula": "C5H12O"
                 },
                 "volume": {
                     "value": 0.2,
@@ -140,16 +145,19 @@
         },
         {
             "actionName": "ShakeAction",
-            "subActionName": "",
             "equipmentName": "magneticStirrer",
             "subEquipmentName": "item-1",
             "startTime": "2024-07-25T12:03:31",
             "endingTime": "2024-07-25T12:15:20",
-            "sampleID": "25",
-            "containerID": "157",
-            "containerBarcode": "1234858858754848",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "speedShaker": {
                 "value": 152,
                 "unit": "rpm",
@@ -162,16 +170,19 @@
         },
         {
             "actionName": "ShakeAction",
-            "subActionName": "",
             "equipmentName": "magneticStirrer",
             "subEquipmentName": "item-1",
             "startTime": "2024-07-25T12:03:31",
             "endingTime": "2024-07-25T12:15:20",
-            "sampleID": "26",
-            "containerID": "158",
-            "containerBarcode": "1234858858754849",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "speedShaker": {
                 "value": 152,
                 "unit": "rpm",
@@ -183,29 +194,29 @@
             "order": "6"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "SamplingAddAction",
             "subActionName": "Sampling",
+            "methodName": "sampling",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "29",
-            "containerID": "159",
-            "containerBarcode": "1234858858754850",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasSample": {
                 "sampleID": "25",
                 "containerID":"157",
                 "containerBarcode":"1234858858754848",
                 "position": "A1",
                 "physicalState": "Liquid",
-                "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
                 "volume": {
                     "value": "?",
                     "unit": "mL",
@@ -218,29 +229,29 @@
             "order": "7"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "SamplingAddAction",
             "subActionName": "Sampling",
+            "methodName": "sampling",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "30",
-            "containerID": "160",
-            "containerBarcode": "1234858858754851",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "26",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "157",
+                "containerBarcode": "1234858858754848",
+                "position": "A1"
+            },
             "hasSample": {
                 "sampleID": "25",
                 "containerID":"157",
                 "containerBarcode":"1234858858754848",
                 "position": "A1",
                 "physicalState": "Liquid",
-                "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
                 "volume": {
                     "value": "?",
                     "unit": "mL",
@@ -253,29 +264,29 @@
             "order": "8"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "SamplingAddAction",
             "subActionName": "Sampling",
+            "methodName": "sampling",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "31",
-            "containerID": "161",
-            "containerBarcode": "1234858858754852",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "31",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "161",
+                "containerBarcode": "1234858858754852",
+                "position": "A1"
+            },
             "hasSample": {
                 "sampleID": "26",
                 "containerID":"158",
                 "containerBarcode":"1234858858754849",
                 "position": "A1",
                 "physicalState": "Liquid",
-                "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
                 "volume": {
                     "value": "?",
                     "unit": "mL",
@@ -288,29 +299,29 @@
             "order": "9"
         },
         {
-            "actionName": "AddAction",
+            "actionName": "SamplingAddAction",
             "subActionName": "Sampling",
+            "methodName": "sampling",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "32",
-            "containerID": "162",
-            "containerBarcode": "1234858858754853",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "32",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "162",
+                "containerBarcode": "1234858858754853",
+                "position": "A1"
+            },
             "hasSample": {
                 "sampleID": "26",
                 "containerID":"158",
                 "containerBarcode":"1234858858754849",
                 "position": "A1",
                 "physicalState": "Liquid",
-                "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
                 "volume": {
                     "value": "?",
                     "unit": "mL",
@@ -323,19 +334,23 @@
             "order": "10"
         },
         {
-            "actionName": "AddAction",
-            "subActionName": "Dilution",
+            "actionName": "DissolutionAddAction",
+            "subActionName": "Dissolution",
+            "methodName": "dissolution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "29",
-            "containerID": "159",
-            "containerBarcode": "1234858858754850",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "29",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "159",
+                "containerBarcode": "1234858858754850",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "105",
@@ -346,7 +361,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "C(Cl)(Cl)Cl",
-                    "swissCatNumber": "",
                     "Inchi": "1S/CHCl3/c2-1(3)4/h1H",
                     "molecularFormula": "CHCl3",
                     "density": {
@@ -366,19 +380,23 @@
             "order": "11"
         },
         {
-            "actionName": "AddAction",
-            "subActionName": "Dilution",
+            "actionName": "DissolutionAddAction",
+            "subActionName": "Dissolution",
+            "methodName": "dissolution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "30",
-            "containerID": "160",
-            "containerBarcode": "1234858858754851",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "30",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "160",
+                "containerBarcode": "1234858858754851",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "105",
@@ -389,7 +407,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "C(Cl)(Cl)Cl",
-                    "swissCatNumber": "",
                     "Inchi": "1S/CHCl3/c2-1(3)4/h1H",
                     "molecularFormula": "CHCl3",
                     "density": {
@@ -409,19 +426,23 @@
             "order": "12"
         },
         {
-            "actionName": "AddAction",
-            "subActionName": "Dilution",
+            "actionName": "DissolutionAddAction",
+            "subActionName": "Dissolution",
+            "methodName": "dissolution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "31",
-            "containerID": "161",
-            "containerBarcode": "1234858858754852",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "31",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "161",
+                "containerBarcode": "1234858858754852",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "105",
@@ -432,7 +453,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "C(Cl)(Cl)Cl",
-                    "swissCatNumber": "",
                     "Inchi": "1S/CHCl3/c2-1(3)4/h1H",
                     "molecularFormula": "CHCl3",
                     "density": {
@@ -452,19 +472,23 @@
             "order": "13"
         },
         {
-            "actionName": "AddAction",
-            "subActionName": "Dilution",
+            "actionName": "DissolutionAddAction",
+            "subActionName": "Dissolution",
+            "methodName": "dissolution",
             "equipmentName": "Micropipette",
-            "subEquipmentName": "",
             "startTime": "2024-07-25T12:02:39",
             "endingTime": "2024-07-25T12:02:41",
             "dispenseState": "Liquid",
             "dispenseType": "volume",
-            "sampleID": "32",
-            "containerID": "162",
-            "containerBarcode": "1234858858754853",
-            "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809",
-            "position": "A1",
+            "relatesTo": {
+                "sampleID": "32",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
+            },
+            "atWell": {
+                "containerID": "162",
+                "containerBarcode": "1234858858754853",
+                "position": "A1"
+            },
             "hasSolvent": {
                 "hasChemical": {
                     "chemicalID": "105",
@@ -475,7 +499,6 @@
                         "unit": "g/mol"
                     },
                     "smiles": "C(Cl)(Cl)Cl",
-                    "swissCatNumber": "",
                     "Inchi": "1S/CHCl3/c2-1(3)4/h1H",
                     "molecularFormula": "CHCl3",
                     "density": {

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -77,6 +77,19 @@ allo-prop:AFX_0000622 a rdf:Property ;
     skos:definition "Point in time when an event starts." ;
     .
 
+
+cat:startDuration a rdf:Property ;
+    skos:prefLabel "duration start interval" ;
+    skos:definition "Start duration in minutes" ;
+    .
+
+
+cat:endingDuration a rdf:Property ;
+    skos:prefLabel "duration end interval" ;
+    skos:definition "End duration in minutes" ;
+    .
+
+
 allo-prop:AFX_0000687 a rdf:Property ;
     skos:prefLabel "barcode" ;
     skos:definition "A barcode is an optical machine-readable representation of data relating to the object to which it is attached. [Wikipedia]" ;
@@ -339,7 +352,7 @@ cat:volume a rdf:Property ;
     skos:prefLabel "volume" ;
     skos:definition "The volume of the sample" ;
     .
-    
+
 cat:isSpmeProcess a rdf:Property ;
     skos:prefLabel "is SPME process" ;
     skos:definition "Solid-phase microextraction (SPME) is a solvent-free sample preparation technique that involves the extraction of analytes from a sample into a solid phase, followed by the desorption of the analytes into a solvent for analysis." ;
@@ -347,7 +360,7 @@ cat:isSpmeProcess a rdf:Property ;
 
 cat:hasSubAction a rdf:Property ;
     skos:prefLabel "has sub action" ;
-    skos:definition "The sub action that is part of the action" ;
+    skos:definition "A narrower specification of the action" ;
     .
 
 cat:hasCartridge a rdf:Property ;
@@ -682,6 +695,14 @@ cat:SolventChangeAction a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf allo-real:AFRE_0000001 ;
     skos:prefLabel "Solvent Change" ;
     skos:definition "A solvent that is selected to replace an existing one. This process involves considering the solvent's properties, compatibility with the analytes, and the analytical techniques employed, ensuring optimal performance and results in the analysis." ; 
+    sh:property [sh:path cat:startDuration ;
+                 sh:node cat:Observation ;
+                 sh:node [sh:property    [sh:path qudt:unit ;
+                                        sh:hasValue unit:MIN] ]];
+    sh:property [sh:path cat:endingDuration ;
+                 sh:node cat:Observation ;
+                 sh:node [sh:property    [sh:path qudt:unit ;
+                                        sh:hasValue unit:MIN] ]];
     sh:property [sh:path cat:isSpmeProcess ; sh:datatype xsd:boolean] ; #isSpmeProcess
     sh:property [sh:path cat:hasSubAction ; sh:class cat:SubAction] ; #hasSubAction
     .
@@ -693,6 +714,7 @@ allo-real:AFRE_0000001 a rdfs:Class, sh:NodeShape ;
     sh:property [sh:path cat:hasPlate ; sh:class cat:Plate] ; #hasPlate
     sh:property [sh:path cat:hasWell ; sh:class cat:Well] ; #hasWell
     sh:property [sh:path allo-res:AFR_0001723 ; sh:datatype xsd:string ] ;#Equipment name ,
+    sh:property [sh:path cat:subAction ; sh:datatype xsd:string ] ;# Subaction name ,
     sh:property [sh:path cat:subEquipmentName ; sh:datatype xsd:string ] ;#subEquipmentName
     sh:property [sh:path schema:name ; sh:datatype xsd:string ] ; #name
     sh:property [sh:path allo-prop:AFX_0000622 ; sh:datatype xsd:dateTime ] ;#startTime ,
@@ -707,17 +729,14 @@ cat:Solvent a rdfs:Class, sh:NodeShape ;
     skos:definition "A solvent is a substance that dissolves a solute, resulting in a solution." ;
     sh:property [sh:path cat:hasChemical ; sh:class obo:CHEBI_25367 ] ; #hasChemical
     sh:property [sh:path cat:volume ; sh:node cat:Observation ; #volume
-                 sh:node [sh:property    [sh:path qudt:unit ; 
+                 sh:node [sh:property    [sh:path qudt:unit ;
                                          sh:hasValue unit:MilliL] ]]
-    .
+
 
 cat:SubAction a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Sub Action" ;
     skos:definition "A sub action is a smaller, constituent action that is part of a larger action." ;
     sh:property [sh:path schema:name ; sh:datatype xsd:string] ; #subActionName
-    sh:property [sh:path allo-prop:AFX_0000622 ; sh:datatype xsd:dateTime] ; #startTime
-    sh:property [sh:path allo-res:AFR_0002423 ; sh:datatype xsd:dateTime] ; #endTime
-
     .
 
 cat:SeparationSubAction a rdfs:Class, sh:NodeShape ;


### PR DESCRIPTION
Data changes:

* can every action still have a `startTime` and a `endingTime` and a `methodName` ?
* can we name actions that are different in a different way? Bravo `AddAction`s are not the same as Synth `AddAction`s
* can we specify the links to `PeakIdentifier` and `Sample` with a `relatesTo` or similar?
* can we group the `hasWell` as `atWell` in Bravo?
