### PR TITLE
fix(json-file bravo1): json syntax and productIdentification

### DIFF
--- a/json-file/3-Bravo/3-Bravo-part1.json
+++ b/json-file/3-Bravo/3-Bravo-part1.json
@@ -11,14 +11,14 @@
             },
             "startTime": "2024-07-25T12:03:31",
             "endingTime": "2024-07-25T12:15:20",
-            "atWell": {
+            "hasWell": {
                 "containerID": "157",
                 "containerBarcode": "1234858858754848",
-                "position": "A1",
-                "productIdentification":{
-                    "sampleID": "1-A1",
-                    "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
-                }
+                "position": "A1"
+            },
+            "productIdentification":{
+                "sampleID": "1-A1",
+                "peakIdentifier": "511359d7-df0d-4018-bfee-ff58585b5809"
             },
             "temperature": {
                 "value": 156,
@@ -45,7 +45,7 @@
             "hasWell": {
                 "containerID": "157",
                 "containerBarcode": "1234858858754848",
-                "position": "A1",
+                "position": "A1"
             },
             "hasSolvent": {
                 "hasChemical": {


### PR DESCRIPTION
* Syntax Error on one well
* transform `atWell` to `hasWell` with `productIdentification` on the same level as `hasWell`