### PR TITLE
fix(ontology producesProduct): belongs to SynthAddAction

### DIFF
--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -655,6 +655,7 @@ cat:isAnalysisOutputOf a rdf:Property ;
 
 cat:SynthAddAction a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf cat:SynthAction ;
+    sh:property [sh:path cat:producesProduct ; sh:class cat:Product ] ; #producesProduct
     sh:property [sh:path cat:hasWell ; sh:class cat:Well] ; #hasWell
     sh:property [sh:path cat:hasSample ; sh:class cat:Sample ] ;
     sh:property [sh:path qudt:quantity ;
@@ -769,7 +770,6 @@ cat:Action a rdfs:Class, sh:NodeShape ;
 cat:SynthAction a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf cat:Action ;
     sh:property [sh:path cat:hasBatch ; sh:class cat:Batch] ; #hasBatch
-    sh:property [sh:path cat:producesProduct ; sh:class cat:Product ] ;  #hasProduct
 .
 
 


### PR DESCRIPTION
On general SynthAction the cat:Product is not visible as it targets the whole plate. Only SynthAddActions specify the Product that they produce