### PR TITLE
fix: missing productIdentification in simple-model bravo-2

### DIFF
--- a/example/simple-model/bravo-2/f81b4bcb-4d4a-41c7-8b34-5610e940d3ca-Bravo_2.json
+++ b/example/simple-model/bravo-2/f81b4bcb-4d4a-41c7-8b34-5610e940d3ca-Bravo_2.json
@@ -408,7 +408,11 @@
                     }
                 }
             },
-            "order": "11"
+            "order": "11",
+            "productIdentification": {
+                "sampleID": "1-A1",
+                "peakIdentifier": "f81b4bcb-4d4a-41c7-8b34-5610e940d3ca"
+            }
         },
         {
             "actionName": "AddAction",


### PR DESCRIPTION
Missing productIdentification from the edits on the example files post ontology Bravo specifications changes. 
It would also be useful to ask for this file to be re uploaded to S3, else the converter will crash. 