### PR TITLE
fix: agilent product representation

### DIFF
--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -596,10 +596,6 @@ cat:peak a rdf:Property ;
     skos:prefLabel "peak" ;
     skos:definition "A peak is a local maximum in the chromatogram that represents the presence of a specific compound or analyte." ;
     .
-allo-res:AFR_0001118 a rdf:Property ;
-    skos:prefLabel "sample Identifier" ;
-    skos:definition "Sample id is a measurement metadata that identifies a sample being measured. [Allotrope]" ;
-    .
 
 obo:IAO_0000590 a rdf:Property ;
     skos:prefLabel "written name" ;
@@ -646,11 +642,6 @@ cat:preparesProduct a rdf:Property ;
     skos:definition "A property to indicate which product gets prepared for analysis (for bravo)" ;
     .
 
-cat:hasProductID a rdf:Property ;
-    skos:prefLabel "has product ID" ;
-    skos:definition "A property to indicate the product ID that a sample document refers to " ;
-    .
-
 cat:isAnalysisOutputOf a rdf:Property ;
     skos:prefLabel "is analysis output of" ;
     skos:definition "A property to relate a peaklist to the product it is an analysis of" ;
@@ -662,7 +653,7 @@ cat:isAnalysisOutputOf a rdf:Property ;
 
 cat:SynthAddAction a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf cat:SynthAction ;
-    sh:property [sh:path cat:producesProduct ; sh:class cat:Product ] ; #producesProduct
+    sh:property [sh:path cat:producesProduct ; sh:class cat:Product ] ; #hasProduct
     sh:property [sh:path cat:hasWell ; sh:class cat:Well] ; #hasWell
     sh:property [sh:path cat:hasSample ; sh:class cat:Sample ] ;
     sh:property [sh:path qudt:quantity ;
@@ -1036,7 +1027,7 @@ cat:ChromatographyColumnDocument a rdfs:Class, sh:NodeShape ;
 cat:SampleDocument a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Sample Document" ;
     skos:definition "A document describing a sample, including identifiers and names for traceability in experimental contexts." ;
-    sh:property [sh:path cat:hasProductID ; sh:class cat:Product ] ; #sample identifier
+    sh:property [sh:path cat:hasProduct ; sh:class cat:Product ] ; #product=sample
     sh:property [sh:path obo:IAO_0000590 ; sh:datatype xsd:string ] ; #written name
     .
 

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -658,7 +658,8 @@ cat:isAnalysisOutputOf a rdf:Property ;
 
 cat:SynthAddAction a rdfs:Class, sh:NodeShape ;
     rdfs:subClassOf cat:SynthAction ;
-    sh:property [sh:path cat:producesProduct ; sh:class cat:Product ] ; #hasProduct
+    sh:property [sh:path cat:producesProduct ; sh:class cat:Product ] ; #producesProduct 
+
     sh:property [sh:path cat:hasWell ; sh:class cat:Well] ; #hasWell
     sh:property [sh:path cat:hasSample ; sh:class cat:Sample ] ;
     sh:property [sh:path qudt:quantity ;

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -1033,7 +1033,8 @@ cat:SampleDocument a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Sample Document" ;
     skos:definition "A document describing a sample, including identifiers and names for traceability in experimental contexts." ;
     sh:property [sh:path cat:hasProduct ; sh:class cat:Product ] ; #product and its identifier
-    sh:property [sh:path allores:AFR_0001118 ; sh:datatype xsd:string ] ; # sample identifier Agilent machine
+    sh:property [sh:path allo-res:AFR_0001118 ; sh:datatype xsd:string ] ; # sample identifier Agilent machine
+
     .
 
 cat:InjectionDocument a rdfs:Class, sh:NodeShape ;

--- a/ontology/catplus_ontology.ttl
+++ b/ontology/catplus_ontology.ttl
@@ -597,6 +597,11 @@ cat:peak a rdf:Property ;
     skos:definition "A peak is a local maximum in the chromatogram that represents the presence of a specific compound or analyte." ;
     .
 
+allo-res:AFR_0001118 a rdf:Property ;
+    skos:prefLabel "sample Identifier" ;
+    skos:definition "Sample id is a measurement metadata that identifies a sample being measured. [Allotrope]" ;
+    .
+
 obo:IAO_0000590 a rdf:Property ;
     skos:prefLabel "written name" ;
     skos:definition "A textual entity that denotes a particular in reality. [IAO]" ;
@@ -1027,8 +1032,8 @@ cat:ChromatographyColumnDocument a rdfs:Class, sh:NodeShape ;
 cat:SampleDocument a rdfs:Class, sh:NodeShape ;
     skos:prefLabel "Sample Document" ;
     skos:definition "A document describing a sample, including identifiers and names for traceability in experimental contexts." ;
-    sh:property [sh:path cat:hasProduct ; sh:class cat:Product ] ; #product=sample
-    sh:property [sh:path obo:IAO_0000590 ; sh:datatype xsd:string ] ; #written name
+    sh:property [sh:path cat:hasProduct ; sh:class cat:Product ] ; #product and its identifier
+    sh:property [sh:path allores:AFR_0001118 ; sh:datatype xsd:string ] ; # sample identifier Agilent machine
     .
 
 cat:InjectionDocument a rdfs:Class, sh:NodeShape ;


### PR DESCRIPTION
Fixes: 

- Put the Agilent machine identifier under the ALLORES property. 
- Put the Product tied to the sample document under hasProduct cat+ specific property